### PR TITLE
Update HTTP referrer docs + Fix error always being shown in FAQ

### DIFF
--- a/LIVE_UPDATES.md
+++ b/LIVE_UPDATES.md
@@ -18,7 +18,8 @@ We access this Sheet in the web app via the
 1. Create a new project "My ETDS 2025".
 1. Enable the Sheets API.
 1. Create API keys: one for prod, one for dev.
-    a. Restrict the prod key to HTTP referrers of your website, e.g. https://etds.ch/*.
+    a. Restrict the prod key to HTTP referrers of your website, e.g. `https://etds.ch/*`.
+       You may also need to allow-list `https://sheets.googleapis.com/* `.
     a. Restrict BOTH keys to the Sheets API.
 1. Set the Share link of the Spreadsheet to "Anyone" and "Viewer" (read-only).
 

--- a/assets/css/weekend.css
+++ b/assets/css/weekend.css
@@ -183,3 +183,14 @@ section.weekend {
 footer {
     display: none;
 }
+
+/* Weekend FAQ */
+
+.status {
+    margin-top: 3em;
+    position: relative;
+}
+
+#accordion a {
+    color: var(--color-primary);
+}

--- a/assets/js/live_faq.js
+++ b/assets/js/live_faq.js
@@ -15,6 +15,7 @@ jQuery(document).ready(async function ($) {
     function displayError() {
         $("#status").fadeOut().promise().done(() => {
             $("#error").fadeIn();
+            $(".status").fadeOut();
         });
     }
 
@@ -33,7 +34,7 @@ jQuery(document).ready(async function ($) {
             </div>`
         }
 
-        $(".status").fadeOut()
+        $(".status").fadeOut();
 
         const accordion = $('#faqAccordion')
         accordion.fadeOut().promise().done(() => {

--- a/assets/pages/weekend/faq.html
+++ b/assets/pages/weekend/faq.html
@@ -1,13 +1,4 @@
-<style>
-    .status {
-        margin-top: 3em;
-        position: relative;
-    }
-
-    #accordion a {
-        color: var(--color-primary);
-    }
-</style>
+<link href="assets/css/weekend.css" rel="stylesheet" />
 
 <section class="intro text-center section-padding">
 	<div class="container wow animated fadeInLeft animated" data-wow-duration="1s" data-wow-delay="0.5s">
@@ -22,6 +13,7 @@
 				</p>
 
 				<p id="error">
+					<br>
 					Something went wrong when trying to load the FAQ.
 					Please try again later by refreshing the page!
 				</p>


### PR DESCRIPTION
Turns out https://sheets.googleapis.com/*  is needed for it to work.

Also fix the error message in the Weekend FAQ page. You can test this by e.g. using uMatrix to block sheets.googleapis.com, then the error should be displayed.