### PR TITLE
Fix status fadeout (again)

### DIFF
--- a/assets/js/live_faq.js
+++ b/assets/js/live_faq.js
@@ -13,9 +13,8 @@ jQuery(document).ready(async function ($) {
     /* UI Functions */
 
     function displayError() {
-        $("#status").fadeOut().promise().done(() => {
+        $(".status").fadeOut().promise().done(() => {
             $("#error").fadeIn();
-            $(".status").fadeOut();
         });
     }
 


### PR DESCRIPTION
The actual bug is that the first fadeout uses an #id when it should be using a .class.